### PR TITLE
Update zksync-web3 to 0.4.0

### DIFF
--- a/local-setup-testing/package.json
+++ b/local-setup-testing/package.json
@@ -14,7 +14,7 @@
     "mocha": "^9.2.1",
     "ts-node": "^10.5.0",
     "typescript": "^4.5.5",
-    "zksync-web3": "^0.3.5"
+    "zksync-web3": "^0.4.0"
   },
   "scripts": {
     "test": "NODE_ENV=test hardhat test"

--- a/local-setup-testing/yarn.lock
+++ b/local-setup-testing/yarn.lock
@@ -3402,7 +3402,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.3.5.tgz#27681e004b9bdef649bdf27140e1aef040c60c62"
-  integrity sha512-NDp70CVYV4CiTnEbuHApzvdFBg9+CMol/GLZ/BKz2YScH09NZdCS4GOvwpe0Mawt4vUKwhMvxATvePzRyqoXKg==
+zksync-web3@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.4.0.tgz#9ab3e8648a6ab11d42b649b3458a0383d6c41bab"
+  integrity sha512-LmrjkQlg2YSR+P0J1NQKtkraCN2ESKfVoMxole3NxesrASQTsk6fR5+ph/8Vucq/Xh8EoAafp07+Q6TavP/TTw==


### PR DESCRIPTION
As the local node docker image now supports the latest zksync-web3 version the project should use the latest version.